### PR TITLE
update registration template admin secret

### DIFF
--- a/dscomp/templates/register.html
+++ b/dscomp/templates/register.html
@@ -30,7 +30,7 @@
       </div>
       <div class="form-group">
 
-          <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
+          <button class="btn btn-light btn-block" type="button" data-toggle="collapse" data-target="#collapseExample" aria-expanded="false" aria-controls="collapseExample">
               <label for="admin">Administrator invite (please leave blank if not an administrator)</label>
           </button>
           <div class="collapse" id="collapseExample">


### PR DESCRIPTION
sorry............. I pushed an older version of my registration template updates in the last PR. It was missing styles that visually hide the admin code box. This PR adds them in. apologies. 